### PR TITLE
Adds a lobby checker in case another script affects the routing bucket

### DIFF
--- a/client/client.lua
+++ b/client/client.lua
@@ -44,3 +44,11 @@ watermark = [[
 
 -- please dont remove this out of respect
 print(watermark)
+
+Citizen.CreateThread(function()
+    while true do
+        Citizen.Wait(5000)
+        local LobbyID = lib.callback.await('JoeV2Lobbys:FetchLobby', false)
+        TriggerEvent("JoeV2Lobbys:SetLobbyHud", LobbyID)
+    end
+end)

--- a/server/server.lua
+++ b/server/server.lua
@@ -75,3 +75,8 @@ function sendToDisc(title, message, footer, color)
     }
     PerformHttpRequest(Config.lobby_webhook, function(err, text, headers) end, 'POST', json.encode({username = "JoeV2 Lobbys", embeds = embed}), { ['Content-Type'] = 'application/json' })
 end
+
+lib.callback.register('JoeV2Lobbys:FetchLobby', function(source)
+    local LobbyID = GetPlayerRoutingBucket(source)
+    return LobbyID
+end)


### PR DESCRIPTION
Every 5 seconds, ox_lib callback checks if the current lobby displayed on the hub is correct and not updated by another script (e.g. admin forcing a user into another routing bucket)